### PR TITLE
Fix #294. Pin Logger to < 1.4.3 untill jekyll > 4.3.2 is released.

### DIFF
--- a/jekyll-rdf.gemspec
+++ b/jekyll-rdf.gemspec
@@ -24,6 +24,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'linkeddata',           '~> 3.2', '>= 3.2.0'
   s.add_runtime_dependency 'sparql-client',        '~> 3.2', '>= 3.2.0'
   s.add_runtime_dependency 'jekyll',               '>= 4.2', '>= 4.2.1'
+  s.add_runtime_dependency 'logger',               '< 1.4.3'
   s.add_development_dependency 'rake',             '~> 13.0', '>= 13.0.6'
   s.add_development_dependency 'rest-client',      '~> 2.0', '>= 2.0.1'
   s.add_development_dependency 'simplecov',        '~> 0.22.0'


### PR DESCRIPTION
cf. https://github.com/jekyll/jekyll/pull/9392